### PR TITLE
Migrate to JuiceShop Jenkins Pipeline to CLI v1.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
   environment {
     TARGET_HOST = 'juice-shop.secure-code-box.svc'
     TARGET_URL = 'http://juice-shop.secure-code-box.svc:3000'
-    ENGINE_URL = 'http://engine-oss.secure-code-box.svc:8080'
+    ENGINE_URL = 'http://engine.secure-code-box.svc:8080'
     ENGINE_CREDS = credentials('scb-internal-dev-scanner-jenkins')
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
     stage('Initilize SCB CLI') {
       steps {
         sh 'rm -f run_scanner.sh'
-        sh 'wget https://raw.githubusercontent.com/secureCodeBox/secureCodeBox/develop/cli/run_scanner.sh'
+        sh 'wget https://raw.githubusercontent.com/secureCodeBox/secureCodeBox/6e507db5d51a6fc1a82910b627c8738982344abe/cli/run_scanner.sh'
         fileExists 'run_scanner.sh'
         sh 'chmod +x run_scanner.sh'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,8 +10,7 @@ pipeline {
     stage('Initilize SCB CLI') {
       steps {
         sh 'rm -f run_scanner.sh'
-        sh 'wget https://raw.githubusercontent.com/secureCodeBox/secureCodeBox/cli-custom-payload/cli/run_scanner.sh'
-        sh 'wget https://raw.githubusercontent.com/secureCodeBox/secureCodeBox/master/cli/sslyze.template.json'
+        sh 'wget https://raw.githubusercontent.com/secureCodeBox/secureCodeBox/develop/cli/run_scanner.sh'
         fileExists 'run_scanner.sh'
         sh 'chmod +x run_scanner.sh'
       }
@@ -20,18 +19,18 @@ pipeline {
       steps {
         parallel(
           "Run Nmap Scan": {
-            sh './run_scanner.sh -b $ENGINE_URL $ELASTIC_URL -i 500 -w 2 -p nmap-scan.json nmap'
-            archiveArtifacts 'job__nmap_result.json,job__nmap_result.readable'
+            sh './run_scanner.sh -b $ENGINE_URL -i 500 -w 2 -a $ENGINE_CREDS -p nmap-scan.json'
+            archiveArtifacts 'job_nmap_result.json'
 
           },
           "Run Arachni Scan": {
-            sh './run_scanner.sh -b $ENGINE_URL $ELASTIC_URL -i 50000 -w 2 -p arachni-scan-long.json arachni'
-            archiveArtifacts 'job__arachni_result.json,job__arachni_result.readable'
+            sh './run_scanner.sh -b $ENGINE_URL -i 50000 -w 2 -a $ENGINE_CREDS -p arachni-scan-long.json'
+            archiveArtifacts 'job_arachni_result.json'
 
           },
           "Run Zap Scan": {
-            sh './run_scanner.sh -b $ENGINE_URL $ELASTIC_URL -i 50000 -w 2 -p zap-scan-quick.json zap'
-            archiveArtifacts 'job__zap_result.json,job__zap_result.readable'
+            sh './run_scanner.sh -b $ENGINE_URL -i 50000 -w 2 -a $ENGINE_CREDS -p zap-scan-quick.json'
+            archiveArtifacts 'job_zap_result.json'
 
           }
         )
@@ -42,6 +41,6 @@ pipeline {
     TARGET_HOST = 'juice-shop.secure-code-box.svc'
     TARGET_URL = 'http://juice-shop.secure-code-box.svc:3000'
     ENGINE_URL = 'http://engine-oss.secure-code-box.svc:8080'
-    ELASTIC_URL = 'http://elasticsearch.secure-code-box.svc:9200'
+    ENGINE_CREDS = credentials('scb-internal-dev-scanner-jenkins')
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,17 +19,17 @@ pipeline {
       steps {
         parallel(
           "Run Nmap Scan": {
-            sh './run_scanner.sh -b $ENGINE_URL -i 500 -w 2 -a $ENGINE_CREDS -p nmap-scan.json'
+            sh './run_scanner.sh -b $ENGINE_URL -i 500 -w 2 -a $ENGINE_CREDS -p nmap-scan.json nmap'
             archiveArtifacts 'job_nmap_result.json'
 
           },
           "Run Arachni Scan": {
-            sh './run_scanner.sh -b $ENGINE_URL -i 50000 -w 2 -a $ENGINE_CREDS -p arachni-scan-long.json'
+            sh './run_scanner.sh -b $ENGINE_URL -i 50000 -w 2 -a $ENGINE_CREDS -p arachni-scan-long.json arachni'
             archiveArtifacts 'job_arachni_result.json'
 
           },
           "Run Zap Scan": {
-            sh './run_scanner.sh -b $ENGINE_URL -i 50000 -w 2 -a $ENGINE_CREDS -p zap-scan-quick.json'
+            sh './run_scanner.sh -b $ENGINE_URL -i 50000 -w 2 -a $ENGINE_CREDS -p zap-scan-quick.json zap'
             archiveArtifacts 'job_zap_result.json'
 
           }

--- a/arachni-scan-long.json
+++ b/arachni-scan-long.json
@@ -1,19 +1,23 @@
 [
   {
-    "name": "In Depth WebApplication Scan with Arachni",
-    "location": "http://juice-shop.secure-code-box.svc:3000/",
-    "attributes": {
-      "ARACHNI_DOM_DEPTH_LIMIT": 30,
-      "ARACHNI_DIR_DEPTH_LIMIT": 10,
-      "ARACHNI_PAGE_LIMIT": 100,
-      "ARACHNI_EXCLUDE_PATTERNS": [
-        ".*socket\\.io.*",
-        ".*node_modules.*",
-        ".*public/images.*",
-        ".*/css.*"
-      ],
-      "ARACHNI_SCAN_METHODS": "*",
-      "ARACHNI_EXTEND_PATH": ["/#/administration"]
+    "name": "arachni",
+    "context": "juiceshop-arachni-in-depth-regular",
+    "target": {
+      "name": "JuiceShop",
+      "location": "http://juice-shop.secure-code-box.svc:3000/",
+      "attributes": {
+        "ARACHNI_DOM_DEPTH_LIMIT": 30,
+        "ARACHNI_DIR_DEPTH_LIMIT": 10,
+        "ARACHNI_PAGE_LIMIT": 100,
+        "ARACHNI_EXCLUDE_PATTERNS": [
+          ".*socket\\.io.*",
+          ".*node_modules.*",
+          ".*public/images.*",
+          ".*/css.*"
+        ],
+        "ARACHNI_SCAN_METHODS": "*",
+        "ARACHNI_EXTEND_PATH": ["/#/administration"]
+      }
     }
   }
 ]

--- a/arachni-scan-quick.json
+++ b/arachni-scan-quick.json
@@ -1,19 +1,23 @@
 [
   {
-    "name": "Quick WebApplication Scan with Arachni",
-    "location": "http://juice-shop.secure-code-box.svc:3000/",
-    "attributes": {
-      "ARACHNI_DOM_DEPTH_LIMIT": 5,
-      "ARACHNI_DIR_DEPTH_LIMIT": 1,
-      "ARACHNI_PAGE_LIMIT": 5,
-      "ARACHNI_EXCLUDE_PATTERNS": [
-        ".*socket\\.io.*",
-        ".*node_modules.*",
-        ".*public/images.*",
-        ".*/css.*"
-      ],
-      "ARACHNI_SCAN_METHODS": "*",
-      "ARACHNI_EXTEND_PATH": ["/#/administration"]
+    "name": "arachni",
+    "context": "juiceshop-arachni-quick",
+    "target": {
+      "name": "JuiceShop",
+      "location": "http://juice-shop.secure-code-box.svc:3000/",
+      "attributes": {
+        "ARACHNI_DOM_DEPTH_LIMIT": 5,
+        "ARACHNI_DIR_DEPTH_LIMIT": 1,
+        "ARACHNI_PAGE_LIMIT": 5,
+        "ARACHNI_EXCLUDE_PATTERNS": [
+          ".*socket\\.io.*",
+          ".*node_modules.*",
+          ".*public/images.*",
+          ".*/css.*"
+        ],
+        "ARACHNI_SCAN_METHODS": "*",
+        "ARACHNI_EXTEND_PATH": ["/#/administration"]
+      }
     }
   }
 ]

--- a/nikto-scan-quick.json
+++ b/nikto-scan-quick.json
@@ -1,9 +1,13 @@
 [
-	{
-		"name" : "Generic WebHost Scan with Nikto",
-    	"location" : "juice-shop.secure-code-box.svc",
-        "attributes" : {
-            "NIKTO_PORTS" : "3000"
-        }
-	}
+  {
+    "name": "nikto",
+    "context": "juiceshop-nikto-regular",
+    "target": {
+      "name": "JuiceShop",
+      "location": "juice-shop.secure-code-box.svc",
+      "attributes": {
+        "NIKTO_PORTS": "3000"
+      }
+    }
+  }
 ]

--- a/nmap-scan.json
+++ b/nmap-scan.json
@@ -1,9 +1,13 @@
 [
-    {
-        "name": "Simple Port Scan  with NMAP",
-        "location": "juice-shop.secure-code-box.svc",
-        "attributes": {
-            "NMAP_PARAMETER": "-Pn"
-        }
+  {
+    "name": "nmap",
+    "context": "juiceshop-nmap-regular",
+    "target": {
+      "name": "JuiceShop",
+      "location": "juice-shop.secure-code-box.svc",
+      "attributes": {
+        "NMAP_PARAMETER": "-Pn"
+      }
     }
+  }
 ]

--- a/zap-scan-quick.json
+++ b/zap-scan-quick.json
@@ -1,18 +1,26 @@
 [
   {
-    "name": "Quick WebApplication Scan with OWASP ZAP",
-    "location": "http://juice-shop.secure-code-box.svc:3000/",
-    "attributes": {
-      "ZAP_BASE_URL": "http://juice-shop.secure-code-box.svc:3000/",
-      "ZAP_SPIDER_MAX_DEPTH": 2,
-      "ZAP_SPIDER_INCLUDE_REGEX":[],
-      "ZAP_SPIDER_EXCLUDE_REGEX":["http://juice-shop.secure-code-box.svc:3000/.git.*",
-                                  "http://juice-shop.secure-code-box.svc:3000/.svn.*",
-                                  "http://juice-shop.secure-code-box.svc:3000/node_modules.*"],
-      "ZAP_SCANNER_INCLUDE_REGEX":[],
-      "ZAP_SCANNER_EXCLUDE_REGEX":["http://juice-shop.secure-code-box.svc:3000/.git.*",
-                                  "http://juice-shop.secure-code-box.svc:3000/.svn.*",
-                                  "http://juice-shop.secure-code-box.svc:3000/node_modules.*"]
+    "name": "zap",
+    "context": "juiceshop-zap-quick",
+    "target": {
+      "name": "JuiceShop",
+      "location": "http://juice-shop.secure-code-box.svc:3000/",
+      "attributes": {
+        "ZAP_BASE_URL": "http://juice-shop.secure-code-box.svc:3000/",
+        "ZAP_SPIDER_MAX_DEPTH": 2,
+        "ZAP_SPIDER_INCLUDE_REGEX": [],
+        "ZAP_SPIDER_EXCLUDE_REGEX": [
+          "http://juice-shop.secure-code-box.svc:3000/.git.*",
+          "http://juice-shop.secure-code-box.svc:3000/.svn.*",
+          "http://juice-shop.secure-code-box.svc:3000/node_modules.*"
+        ],
+        "ZAP_SCANNER_INCLUDE_REGEX": [],
+        "ZAP_SCANNER_EXCLUDE_REGEX": [
+          "http://juice-shop.secure-code-box.svc:3000/.git.*",
+          "http://juice-shop.secure-code-box.svc:3000/.svn.*",
+          "http://juice-shop.secure-code-box.svc:3000/node_modules.*"
+        ]
+      }
     }
   }
 ]


### PR DESCRIPTION
Migrates JuiceShop Jenkins Pipeline to use the new cli version, which properly supports api authentication.